### PR TITLE
Adding basic SMP support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,14 @@ all: clean kernel8.img
 boot.o: boot.S
 	${CC} ${CFLAGS} -c boot.S -o boot.o 
 
+proc.o: proc.S
+	${CC} ${CFLAGS} -c proc.S -o proc.o 
+
 %.o: %.c
 	${CC} ${CFLAGS} -c $< -o $@
 
-kernel8.img: boot.o ${OBJS}
-	${LD} boot.o ${OBJS} -T linker.ld -o kernel8.elf
+kernel8.img: boot.o proc.o ${OBJS}
+	${LD} boot.o proc.o ${OBJS} -T linker.ld -o kernel8.elf -g
 	${TOOLCHAIN}objcopy -O binary kernel8.elf kernel8.img
 
 clean:

--- a/boot.S
+++ b/boot.S
@@ -1,32 +1,21 @@
 .section ".text.boot"
 
-
-#define BIT(x) (1 << (x))
-
 .global _start
 .global __heap_start
 .global __heap_size
 .global __heap_end
 
-#define SMPEN	BIT(6)
-
 _start:
     // read cpu id, stop slave cores
+
     mrs     x1, mpidr_el1
     and     x1, x1, #3
-    cbz     x1, 2f
-    // cpu id > 0, stop
-1:  wfe
-    b       1b
-2:  // cpu id == 0
 
-    // set top of stack just before our code (stack grows to a lower address per AAPCS64)
-    ldr     x1, =_start
-    mov     sp, x1
+    bl setup_stack 
 
     // clear bss
     ldr     x1, =__bss_start
-    ldr     w2, =__bss_size
+    ldr     w2, =BSS_SIZE
 3:  cbz     w2, 4f
     str     xzr, [x1], #8
     sub     w2, w2, #1
@@ -52,4 +41,4 @@ _start:
     // jump to C code, should not return
 5:  bl      main
     // for failsafe, halt this core too
-    b       1b
+    //b       1b

--- a/hobos/smp.h
+++ b/hobos/smp.h
@@ -17,5 +17,7 @@
 #define MAX_REMOTE_CORE_ID	3
 
 int run_process(uint64_t fn_addr, uint8_t cpu_id);
+uint8_t get_curr_core_id(void);
+uint64_t get_curr_stack_base(int core_id);
 
 #endif

--- a/kernel.c
+++ b/kernel.c
@@ -4,18 +4,14 @@
 #include "hobos/mmio.h"
 #include "hobos/smp.h"
 
-/* test print */
-void test_print(void)
-{
-	puts("Hello\n");
-}
+extern int setup_stack(void);
 
 /* I'm alive */
 void heartbeat(void)
 {
-	run_process((uint64_t) test_print, 1);
-	run_process((uint64_t) test_print, 2);
-	run_process((uint64_t) test_print, 3);
+	run_process((uint64_t) setup_stack, 1);
+	run_process((uint64_t) setup_stack, 2);
+	run_process((uint64_t) setup_stack, 3);
 }
 
 void main()
@@ -28,7 +24,6 @@ void main()
 
 	while (1) {
 		//start shell here
-		delay(1000);
 	}
 
 }

--- a/linker.ld
+++ b/linker.ld
@@ -1,5 +1,13 @@
 ENTRY(_start)
 
+
+BSS_SIZE = 0x4000;
+
+CORE_STACK_BASE = 0x86000;
+CORE_STACK_SIZE = 0x1000;
+
+PAGE_SIZE = 0x4000;
+
 SECTIONS
 {
     /* Starts at LOADER_ADDR. */
@@ -10,9 +18,10 @@ SECTIONS
     .text :
     {
         KEEP(*(.text.boot))
+        KEEP(*(.text.proc))
         *(.text)
     }
-    . = ALIGN(4096); /* align to page size */
+    . = ALIGN(PAGE_SIZE); /* align to page size */
     __text_end = .;
 
     __rodata_start = .;
@@ -20,7 +29,7 @@ SECTIONS
     {
         *(.rodata)
     }
-    . = ALIGN(4096); /* align to page size */
+    . = ALIGN(PAGE_SIZE); /* align to page size */
     __rodata_end = .;
 
     __data_start = .;
@@ -28,18 +37,56 @@ SECTIONS
     {
         *(.data)
     }
-    . = ALIGN(4096); /* align to page size */
+    . = ALIGN(PAGE_SIZE); /* align to page size */
     __data_end = .;
 
     __bss_start = .;
     .bss :
     {
+	. += BSS_SIZE;
         bss = .;
         *(.bss)
     }
-    . = ALIGN(4096); /* align to page size */
+    . = ALIGN(PAGE_SIZE); /* align to page size */
     __bss_end = .;
-    __bss_size = __bss_end - __bss_start;
+
+
+    /* SMP Stack */
+    /* NOTE: ARM stack grows downwards */
+   
+    . = CORE_STACK_BASE;
+    .core0_stack :
+    {
+	. = . + CORE_STACK_SIZE;
+	*(.core0_stack)
+	__core0_stack = .;	
+    }
+    . = ALIGN(PAGE_SIZE); /* align to page size */
+
+    .core1_stack :
+    {
+        . = . + CORE_STACK_SIZE;
+        *(.core1_stack)
+        __core1_stack = .;
+    }
+    . = ALIGN(PAGE_SIZE); /* align to 16 bytes */
+    
+    .core2_stack :
+    {
+        . = . + CORE_STACK_SIZE;
+        *(.core2_stack)
+        __core2_stack = .;
+    }
+    . = ALIGN(PAGE_SIZE); /* align to 16 bytes */
+    
+    .core3_stack :
+    {
+        . = . + CORE_STACK_SIZE;
+        *(.core3_stack)
+        __core3_stack = .;
+    }
+    . = ALIGN(PAGE_SIZE); /* align to 16 bytes */
+
     __end = .;
 }
 

--- a/proc.S
+++ b/proc.S
@@ -1,0 +1,44 @@
+.section ".text.proc"
+
+.global setup_stack
+.global curr_core_id
+
+#define CORE_STACK_BASE	0x86000
+#define CORE_STACK_SIZE	0x1000
+
+
+
+//Check https://github.com/rsta2/circle/blob/927941cec722f530a23d0f636f03480dd9972056/lib/startup64.S#L106
+//for RPI5
+setup_stack:
+
+    //get core id
+    mrs x0, mpidr_el1
+    and x0, x0, #0x3
+ 
+    //core 0 does not need offset
+    cbz	x0, 1f
+
+    //get offset from base
+    ldr x2, =CORE_STACK_SIZE
+    mul x0, x0, x2
+
+1:
+    //get stack associated to core id
+    ldr x1, =CORE_STACK_BASE
+    sub x1, x1, x0
+    mov sp, x1
+
+    //continue execution to main
+    //for core 0
+    cbnz x0, exec
+    ret
+
+exec:
+    b park_and_wait
+
+
+curr_core_id:
+    mrs x0, mpidr_el1
+    and x0, x0, #0x3
+    ret

--- a/smp.c
+++ b/smp.c
@@ -1,4 +1,9 @@
 #include "hobos/smp.h"
+#include "hobos/kstdio.h"
+
+extern int curr_core_id(void);
+
+uint64_t *cpu_spin_table = (uint64_t *) SPIN_TABLE_BASE;
 
 int run_process(uint64_t fn_addr, uint8_t cpu_id)
 {
@@ -6,9 +11,19 @@ int run_process(uint64_t fn_addr, uint8_t cpu_id)
     if (cpu_id > MAX_REMOTE_CORE_ID)
 	return -1;
 
-    *(uint64_t *) (SPIN_TABLE_BASE + (cpu_id * 8)) = fn_addr;
+    cpu_spin_table[cpu_id] = fn_addr;
 
     //wake up processors with "SEND EVENT"
     __asm__ volatile("sev");
+
     return 0;
+}
+
+void park_and_wait (void)
+{
+	kprintf ("Hello from core %d\n", curr_core_id());
+
+	while (1) {
+		__asm__ volatile ("wfe");
+	}
 }


### PR DESCRIPTION
Added common stack setup for all cores and basic SMP interface for testing

Idea is that I can probably use interrupts or IPCM to break cores out from their while loop where I've parked them for now. 

This is an extremely rudimentary implementation which will later be fleshed out into threads and processes.

Tested with qemu on RPI 3:

```
make
qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial null -serial stdio -s
```
Output:
```
HHello froHello from core 3m core 2ello fro
m core 1O
```