### PR TITLE
Threading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,14 @@ boot.o: boot.S
 proc.o: proc.S
 	${CC} ${CFLAGS} -c proc.S -o proc.o 
 
+mutex.o: mutex.S
+	${CC} ${CFLAGS} -c mutex.S -o mutex.o 
+
 %.o: %.c
 	${CC} ${CFLAGS} -c $< -o $@
 
-kernel8.img: boot.o proc.o ${OBJS}
-	${LD} boot.o proc.o ${OBJS} -T linker.ld -o kernel8.elf -g
+kernel8.img: boot.o proc.o mutex.o ${OBJS}
+	${LD} boot.o proc.o mutex.o ${OBJS} -T linker.ld -o kernel8.elf -g
 	${TOOLCHAIN}objcopy -O binary kernel8.elf kernel8.img
 
 clean:

--- a/hobos/lib/task.h
+++ b/hobos/lib/task.h
@@ -1,19 +1,29 @@
-#ifndef __THREAD_H
-#define __THREAD_H
+#ifndef __TASK_H
+#define __TASK_H
 
-//We want simple thread implementation
-//
-//1: A task is created and added to workqueue
-//2: When the requested core is available, create a
-//thread and send it over to be executed
+#include <stdint.h>
 
-struct task {
-	uint8_t tid;	//thread associated to task
-	uint8_t core_id; //any preferred core id
+/* We want simple thread implementation
+ *
+ * 1: A task is created and added to workqueue
+ * 2: When the requested core is available, create a
+ * thread and send it over to be executed
+ */
+
+#define TASK(tsk, core_id, fn_addr) \
+    struct task_struct tsk = { \
+        .core_id = core_id, \
+        .fn_addr = (uint64_t)(fn_addr) \
+    } 
+
+
+struct task_struct {
+	uint8_t tid;		//thread associated to task
+	uint8_t core_id; 	//any preferred core id
 
 	uint64_t fn_addr; 
-	uint64_t *args;
-	uint64_t *result
+//	uint64_t *args;
+//	uint64_t *result
 
 	uint8_t completed;
 };
@@ -22,6 +32,6 @@ struct wk_queue {
 	//LIST(tasks)
 };
 
-void queue_task(void);
+void queue_task(struct task_struct *tsk);
 
-
+#endif

--- a/hobos/lib/task.h
+++ b/hobos/lib/task.h
@@ -1,0 +1,27 @@
+#ifndef __THREAD_H
+#define __THREAD_H
+
+//We want simple thread implementation
+//
+//1: A task is created and added to workqueue
+//2: When the requested core is available, create a
+//thread and send it over to be executed
+
+struct task {
+	uint8_t tid;	//thread associated to task
+	uint8_t core_id; //any preferred core id
+
+	uint64_t fn_addr; 
+	uint64_t *args;
+	uint64_t *result
+
+	uint8_t completed;
+};
+
+struct wk_queue {
+	//LIST(tasks)
+};
+
+void queue_task(void);
+
+

--- a/hobos/lib/thread.h
+++ b/hobos/lib/thread.h
@@ -42,9 +42,7 @@ struct thread_struct {
 };
 
 
-void init_threading(void);
 uint8_t incoming_thread_exists(uint8_t core_id);
 void queue_thread(struct task_struct *tsk);
-void check_thread_status(void);
 
 #endif

--- a/hobos/lib/thread.h
+++ b/hobos/lib/thread.h
@@ -41,9 +41,6 @@ struct thread_struct {
 
 };
 
-struct thread_queue {
-	//LIST(threads)
-};
 
 void init_threading(void);
 uint8_t incoming_thread_exists(uint8_t core_id);

--- a/hobos/lib/thread.h
+++ b/hobos/lib/thread.h
@@ -1,7 +1,9 @@
 #ifndef __THREAD_H
 #define __THREAD_H
 
+#include "task.h"
 #include <stdint.h>
+#include "../kstdio.h"
 
 /* 
  * We want simple thread implementation
@@ -20,28 +22,32 @@
  * suspend execution
  * 
  * TODO: suspend / migration
-*/
+ * */
 
-struct thread {
+#define	ANY_CORE	0xFF
+
+#define INACTIVE	0xFF
+
+#define PRINT_THREAD(t)	kprintf("tid:%d\ncore:%d\nfn:%x\n", t->tid, t->core_id, t->fn_addr);
+
+struct thread_struct {
 	uint8_t tid;
 	uint8_t core_id;
 
 	uint64_t fn_addr;
-	uint64_t *args;
-	uint64_t *result;
+//	uint64_t *args;
+//	uint64_t *result;
+//	TODO: Add more meta data
 
-	uint8_t completed;
-};
-
-struct wk_queue {
-	//LIST(tasks)
 };
 
 struct thread_queue {
 	//LIST(threads)
 };
 
-void queue_thread(void);
+void init_threading(void);
+uint8_t incoming_thread_exists(uint8_t core_id);
+void queue_thread(struct task_struct *tsk);
 void check_thread_status(void);
 
 #endif

--- a/hobos/lib/thread.h
+++ b/hobos/lib/thread.h
@@ -1,0 +1,47 @@
+#ifndef __THREAD_H
+#define __THREAD_H
+
+#include <stdint.h>
+
+/* 
+ * We want simple thread implementation
+ * 
+ * 1) A task is created and added to workqueue
+ * 2) When the requested core is available, create a
+ *    thread and send it over to be executed
+ * 3) if the core is not available, move to other tasks
+ *    that can be sent over
+ * 
+ * This concept assumes that core 0 takes the place
+ * of a dedicated thread scheduler for now
+ * 
+ * Execution is done at a first come first serve basis
+ * since currently there is no wait for IO which might
+ * suspend execution
+ * 
+ * TODO: suspend / migration
+*/
+
+struct thread {
+	uint8_t tid;
+	uint8_t core_id;
+
+	uint64_t fn_addr;
+	uint64_t *args;
+	uint64_t *result;
+
+	uint8_t completed;
+};
+
+struct wk_queue {
+	//LIST(tasks)
+};
+
+struct thread_queue {
+	//LIST(threads)
+};
+
+void queue_thread(void);
+void check_thread_status(void);
+
+#endif

--- a/hobos/mutex.h
+++ b/hobos/mutex.h
@@ -4,12 +4,17 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define LOCKED		1
-#define UNLOCKED	0
+#define LOCKED			1
+#define UNLOCKED		0
 
-#define MUTEX(x)	mutex_t	x;
+#define MUTEX(x)		mutex_t	x
+#define MUTEX_VECTOR(x, n)	mutex_t	x[n]
 
-typedef uint8_t	mutex_t;
+/* This needs to be 64 bits, else 
+ * writes trample multiple entries due to 
+ * 64 bit function addresses 
+ * */
+typedef uint64_t		mutex_t;
 
 extern void lock_mutex (mutex_t *mutex);
 extern void unlock_mutex (mutex_t *mutex);

--- a/hobos/mutex.h
+++ b/hobos/mutex.h
@@ -13,5 +13,6 @@ typedef uint8_t	mutex_t;
 
 extern void lock_mutex (mutex_t *mutex);
 extern void unlock_mutex (mutex_t *mutex);
+extern mutex_t get_mutex_state (mutex_t *mutex);
 
 #endif

--- a/hobos/mutex.h
+++ b/hobos/mutex.h
@@ -1,0 +1,17 @@
+#ifndef __MUTEX_H
+#define __MUTEX_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define LOCKED		1
+#define UNLOCKED	0
+
+#define MUTEX(x)	mutex_t	x;
+
+typedef uint8_t	mutex_t;
+
+extern void lock_mutex (mutex_t *mutex);
+extern void unlock_mutex (mutex_t *mutex);
+
+#endif

--- a/hobos/smp.h
+++ b/hobos/smp.h
@@ -19,6 +19,9 @@
 extern int curr_core_id(void);
 extern int setup_stack(void);
 
+extern int curr_sp(void);
+extern int curr_pc(void);
+
 int init_smp(void);
 int queue_on_proc(uint64_t fn_addr, uint8_t cpu_id);
 

--- a/hobos/smp.h
+++ b/hobos/smp.h
@@ -14,10 +14,9 @@
 //TODO: Add mailbox support for reading processor messages
 
 #define SPIN_TABLE_BASE		0xD8
-#define MAX_REMOTE_CORE_ID	3
+#define MAX_CORES	4
 
+int init_smp(void);
 int run_process(uint64_t fn_addr, uint8_t cpu_id);
-uint8_t get_curr_core_id(void);
-uint64_t get_curr_stack_base(int core_id);
 
 #endif

--- a/hobos/smp.h
+++ b/hobos/smp.h
@@ -16,7 +16,9 @@
 #define SPIN_TABLE_BASE		0xD8
 #define MAX_CORES	4
 
+
+
 int init_smp(void);
-int run_process(uint64_t fn_addr, uint8_t cpu_id);
+int queue_on_proc(uint64_t fn_addr, uint8_t cpu_id);
 
 #endif

--- a/hobos/smp.h
+++ b/hobos/smp.h
@@ -14,9 +14,10 @@
 //TODO: Add mailbox support for reading processor messages
 
 #define SPIN_TABLE_BASE		0xD8
-#define MAX_CORES	4
+#define MAX_CORES		4
 
-
+extern int curr_core_id(void);
+extern int setup_stack(void);
 
 int init_smp(void);
 int queue_on_proc(uint64_t fn_addr, uint8_t cpu_id);

--- a/kernel.c
+++ b/kernel.c
@@ -3,34 +3,68 @@
 #include "hobos/kstdio.h"
 #include "hobos/mmio.h"
 #include "hobos/smp.h"
-#include "hobos/mutex.h"
+#include "hobos/lib/thread.h"
+#include "hobos/lib/task.h"
+
+int test_cntr1 = 0;
+int test_cntr2 = 0;
+int test_cntr3 = 0;
 
 void test_print1(void)
 {
-	kprintf("Hello again 1\n");
+	kprintf("Hello again 1 %d*\n", test_cntr1++);
 	return;
 }
 
 void test_print2(void)
 {
-	kprintf("Hello again 2\n");
+	kprintf("Hello again 2 %d*\n", test_cntr2++);
 	return;
 }
 
-MUTEX(x);
+void test_print3(void)
+{
+	kprintf("Hello again 3 %d*\n", test_cntr3++);
+	return;
+}
+
 /* I'm alive */
 void heartbeat(void)
 {
 
-	queue_on_proc((uint64_t) test_print1, 0);
-	unlock_mutex(&x);
+    struct task_struct tsk1 = { 
+        .core_id = 3, 
+        .fn_addr = (uint64_t)(test_print1) 
+    };
+    
+    struct task_struct tsk2 = { 
+        .core_id = 1, 
+        .fn_addr = (uint64_t)(test_print2) 
+    };
 
-	lock_mutex(&x);
-	kprintf("mutex:%d *\n", get_mutex_state(&x));
-	unlock_mutex(&x);
+    struct task_struct tsk3 = { 
+        .core_id = 2, 
+        .fn_addr = (uint64_t)(test_print3) 
+    };
 
-	kprintf("mutex:%d *\n", get_mutex_state(&x));
+//	TASK(tsk1, 3, test_print1);
+//	TASK(tsk2, 3, test_print2);
 
+	queue_thread(&tsk1);
+	queue_thread(&tsk2);
+	
+	queue_thread(&tsk1);
+	queue_thread(&tsk2);
+
+	queue_thread(&tsk1);
+	queue_thread(&tsk2);
+	
+	queue_thread(&tsk1);
+	queue_thread(&tsk2);
+	
+	queue_thread(&tsk3);
+	queue_thread(&tsk2);
+	queue_thread(&tsk3);
 }
 
 void main()
@@ -38,12 +72,14 @@ void main()
 	get_rpi_version();
 	mmio_init();
 	init_console();
-	init_smp();
 
+	init_smp();
+	init_threading();
 	heartbeat();
 
 	while (1) {
 		//start shell here
+		__asm__ volatile ("wfe");
 	}
 
 }

--- a/kernel.c
+++ b/kernel.c
@@ -3,7 +3,7 @@
 #include "hobos/kstdio.h"
 #include "hobos/mmio.h"
 #include "hobos/smp.h"
-
+#include "hobos/mutex.h"
 
 void test_print1(void)
 {
@@ -17,14 +17,20 @@ void test_print2(void)
 	return;
 }
 
+MUTEX(x);
 /* I'm alive */
 void heartbeat(void)
 {
-	//TODO: threading implementation
-	//with proper mutex implementation, we
-	//should be able to see both these functions executed
-	run_process((uint64_t) test_print1, 1);
-	run_process((uint64_t) test_print2, 2);
+
+	queue_on_proc((uint64_t) test_print1, 0);
+	unlock_mutex(&x);
+
+	lock_mutex(&x);
+	queue_on_proc((uint64_t) test_print2, 2);
+	unlock_mutex(&x);
+
+	//pause core 2
+	queue_on_proc((uint64_t) 0x0, 2);
 
 }
 

--- a/kernel.c
+++ b/kernel.c
@@ -4,8 +4,6 @@
 #include "hobos/mmio.h"
 #include "hobos/smp.h"
 
-extern int setup_stack(void);
-
 
 void test_print1(void)
 {
@@ -22,17 +20,11 @@ void test_print2(void)
 /* I'm alive */
 void heartbeat(void)
 {
-	run_process((uint64_t) setup_stack, 1);
-	run_process((uint64_t) setup_stack, 2);
-
 	//TODO: threading implementation
 	//with proper mutex implementation, we
 	//should be able to see both these functions executed
 	run_process((uint64_t) test_print1, 1);
-	run_process((uint64_t) test_print1, 2);
-	run_process((uint64_t) test_print1, 2);
-	run_process((uint64_t) test_print1, 2);
-	run_process((uint64_t) test_print2, 1);
+	run_process((uint64_t) test_print2, 2);
 
 }
 
@@ -41,6 +33,7 @@ void main()
 	get_rpi_version();
 	mmio_init();
 	init_console();
+	init_smp();
 
 	heartbeat();
 

--- a/kernel.c
+++ b/kernel.c
@@ -26,11 +26,10 @@ void heartbeat(void)
 	unlock_mutex(&x);
 
 	lock_mutex(&x);
-	queue_on_proc((uint64_t) test_print2, 2);
+	kprintf("mutex:%d *\n", get_mutex_state(&x));
 	unlock_mutex(&x);
 
-	//pause core 2
-	queue_on_proc((uint64_t) 0x0, 2);
+	kprintf("mutex:%d *\n", get_mutex_state(&x));
 
 }
 

--- a/kernel.c
+++ b/kernel.c
@@ -74,7 +74,6 @@ void main()
 	init_console();
 
 	init_smp();
-	init_threading();
 	heartbeat();
 
 	while (1) {

--- a/kernel.c
+++ b/kernel.c
@@ -65,6 +65,9 @@ void heartbeat(void)
 	queue_thread(&tsk3);
 	queue_thread(&tsk2);
 	queue_thread(&tsk3);
+
+
+	kprintf("sp: 0x%x pc: 0x%x\n", curr_sp, curr_pc);
 }
 
 void main()

--- a/kernel.c
+++ b/kernel.c
@@ -33,7 +33,7 @@ void heartbeat(void)
 {
 
     struct task_struct tsk1 = { 
-        .core_id = 3, 
+        .core_id = 0, 
         .fn_addr = (uint64_t)(test_print1) 
     };
     

--- a/kernel.c
+++ b/kernel.c
@@ -6,12 +6,34 @@
 
 extern int setup_stack(void);
 
+
+void test_print1(void)
+{
+	kprintf("Hello again 1\n");
+	return;
+}
+
+void test_print2(void)
+{
+	kprintf("Hello again 2\n");
+	return;
+}
+
 /* I'm alive */
 void heartbeat(void)
 {
 	run_process((uint64_t) setup_stack, 1);
 	run_process((uint64_t) setup_stack, 2);
-	run_process((uint64_t) setup_stack, 3);
+
+	//TODO: threading implementation
+	//with proper mutex implementation, we
+	//should be able to see both these functions executed
+	run_process((uint64_t) test_print1, 1);
+	run_process((uint64_t) test_print1, 2);
+	run_process((uint64_t) test_print1, 2);
+	run_process((uint64_t) test_print1, 2);
+	run_process((uint64_t) test_print2, 1);
+
 }
 
 void main()

--- a/kstdio.c
+++ b/kstdio.c
@@ -3,6 +3,7 @@
 #include "hobos/mmio.h"
 #include "hobos/nostdlibc_arg.h"
 #include "hobos/uart.h"
+#include "hobos/mutex.h"
 
 
 extern uint8_t rpi_version;
@@ -62,13 +63,16 @@ void puts(char *c)
 		mini_uart_puts(c);
 }
 
+MUTEX(uart_mut) = 0;
 int kprintf(const char *format, ...)
 {
 	va_list args;
 	int printed;
 
 	va_start(args, format);
+	lock_mutex(&uart_mut);
 	printed = vprintf(format, args);
+	unlock_mutex(&uart_mut);
 	va_end(args);
 	return printed;
 

--- a/linker.ld
+++ b/linker.ld
@@ -19,6 +19,7 @@ SECTIONS
     {
         KEEP(*(.text.boot))
         KEEP(*(.text.proc))
+        KEEP(*(.text.mutex))
         *(.text)
     }
     . = ALIGN(PAGE_SIZE); /* align to page size */

--- a/mutex.S
+++ b/mutex.S
@@ -1,0 +1,33 @@
+.section ".text.mutex"
+
+.global lock_mutex
+.global unlock_mutex
+.global get_mutex_state
+
+//https://developer.arm.com/documentation/dht0008/a/arm-synchronization-primitives/practical-uses/implementing-a-mutex
+
+#define LOCKED		1
+#define UNLOCKED	0
+
+/* arg1 = mutex addr */
+lock_mutex:
+1:  ldaxr   w1, [x0]           // load lock
+    cbnz    w1, 1b             // if locked, retry
+    mov     w1, #LOCKED
+    stxr    w2, w1, [x0]       // try to store 1 (lock)
+    cbnz    w2, 1b             // if store failed, retry
+    ret
+
+
+get_mutex_state:
+    dmb 	st		
+1:  ldaxr   w0, [x0]           // load lock
+    ret
+
+unlock_mutex:
+    ldr		x1, =UNLOCKED
+    dmb		st			//data barrier, needed before releasing exclusive resource
+    str		x1, [x0]	//unlock
+    sev				//signal that lock is ready to the ones waiting
+    ret
+

--- a/mutex.S
+++ b/mutex.S
@@ -15,9 +15,11 @@ lock_mutex:
     cbnz    w1, 1b             // if locked, retry
     mov     w1, #LOCKED
     stxr    w2, w1, [x0]       // try to store 1 (lock)
+
+    //TODO: Maybe return here and let the program 
+    //decide on triggering a retry
     cbnz    w2, 1b             // if store failed, retry
     ret
-
 
 get_mutex_state:
     dmb 	st		

--- a/proc.S
+++ b/proc.S
@@ -2,6 +2,8 @@
 
 .global setup_stack
 .global curr_core_id
+.global curr_sp
+.global curr_pc
 
 #define CORE_STACK_BASE	0x86000
 #define CORE_STACK_SIZE	0x1000
@@ -42,4 +44,12 @@ exec:
 curr_core_id:
     mrs x0, mpidr_el1
     and x0, x0, #0x3
+    ret
+
+curr_sp:
+    mov x0, sp
+    ret
+
+curr_pc:
+    adr	x0, .
     ret

--- a/proc.S
+++ b/proc.S
@@ -35,7 +35,8 @@ setup_stack:
     ret
 
 exec:
-    b park_and_wait
+    bl park_and_wait
+    ret
 
 
 curr_core_id:

--- a/smp.c
+++ b/smp.c
@@ -1,11 +1,16 @@
 #include "hobos/smp.h"
 #include "hobos/mutex.h"
+#include "hobos/lib/thread.h"
+#include "hobos/kstdio.h"
 
-extern int curr_core_id(void);
-extern int setup_stack(void);
+extern MUTEX_VECTOR(core_incoming_event, MAX_CORES);
+extern struct thread_struct active_threads[2*MAX_CORES];
 
+MUTEX_VECTOR(core_spin_entry, MAX_CORES) = {0};
 uint64_t *cpu_spin_table = (uint64_t *) SPIN_TABLE_BASE;
 
+//makes sure only 1 fn executes at a time
+MUTEX_VECTOR(core_exec, MAX_CORES) = {0};
 
 /* In order to queue a workload we need to go through the following
  * steps:
@@ -35,30 +40,72 @@ int init_smp(void)
  * It only updates the spintable function address the 
  * processor uses (see park_and_wait).
  * */
-int queue_on_proc(uint64_t fn_addr, uint8_t cpu_id)
+int queue_on_proc(uint64_t fn_addr, uint8_t core_id)
 {
-
-	if (cpu_id >= MAX_CORES)
+	if (core_id >= MAX_CORES)
 		return -1;
 
-	if (!cpu_id) {
+	/* This assumes for now that queue_on_proc can
+	 * ONLY be called from core 0, otherwise, which makes
+	 * it a special case since all ops will be sequential 
+	 * */
+	if (!core_id) {
 		((void (*)(void)) fn_addr)();
 		return 0;
 	}
 
-	cpu_spin_table[cpu_id] = fn_addr;
+	lock_mutex(&core_spin_entry[core_id]);
+	cpu_spin_table[core_id] = fn_addr;
+	unlock_mutex(&core_spin_entry[core_id]);
+	
+	/* Wakeup suspended processors, barrier is already there
+	 * in mutex functions 
+	 * */
 	__asm__ volatile("dsb sy; sev");
 	return 0;
 }
 
+static void cleanup(uint8_t core_id)
+{
+	if (incoming_thread_exists(core_id))
+		return;
+
+	lock_mutex(&core_spin_entry[core_id]);
+	cpu_spin_table[core_id] = 0x0;
+	unlock_mutex(&core_spin_entry[core_id]);
+}
+
+static uint64_t read_spin_table(uint8_t core_id)
+{
+	uint64_t val;
+
+	lock_mutex(&core_spin_entry[core_id]);
+	val = cpu_spin_table[core_id];
+	unlock_mutex(&core_spin_entry[core_id]);
+
+	return val;
+}
 
 void park_and_wait (void)
 {
 	uint8_t core_id = curr_core_id();
 
+	cleanup(core_id);
 	while (1) {
-		if (cpu_spin_table[core_id]) 
-			( (void (*)(void)) cpu_spin_table[core_id])();
+		if (read_spin_table(core_id) != 0x0) {
+			
+			/* assumes you must have accquired the incoming event lock,
+			 * since now you are in execution, you dont need it anymore,
+			 * let others queue */
+
+			lock_mutex(&core_exec[core_id]);
+			unlock_mutex(&core_incoming_event[core_id]);
+			
+			((void (*)(void)) cpu_spin_table[core_id])();
+			
+			cleanup(core_id);
+			unlock_mutex(&core_exec[core_id]);
+		}
 
 		/* suspend and wait for event */
 		__asm__ volatile ("wfe");

--- a/smp.c
+++ b/smp.c
@@ -5,25 +5,46 @@ extern int curr_core_id(void);
 
 uint64_t *cpu_spin_table = (uint64_t *) SPIN_TABLE_BASE;
 
+//TODO: We need a mutex here to preserve a read/write order
+//for the spin table
+
 int run_process(uint64_t fn_addr, uint8_t cpu_id)
 {
 
-    if (cpu_id > MAX_REMOTE_CORE_ID)
-	return -1;
+	if (cpu_id > MAX_REMOTE_CORE_ID)
+		return -1;
+	
+	cpu_spin_table[cpu_id] = fn_addr;
+	
+	//data sync barrier
+	__asm__ volatile("dsb sy");
+	__asm__ volatile("sev");
 
-    cpu_spin_table[cpu_id] = fn_addr;
-
-    //wake up processors with "SEND EVENT"
-    __asm__ volatile("sev");
-
-    return 0;
+	return 0;
 }
 
+
+//TODO:
+//if we attempt to clear or set the spin table, we might
+//lose a read or write incoming from another processor.
+//
+//This is why we need a mutex before queueing more than
+//one processors
+//
+//This current implementation works, just about, with the 
+//current implementation, but has no guarantees.
 void park_and_wait (void)
 {
-	kprintf ("Hello from core %d\n", curr_core_id());
+	uint8_t core_id = curr_core_id();
 
 	while (1) {
+	
+		//data sync barrier
+		__asm__ volatile("dsb sy");
+		
+		if (cpu_spin_table[core_id]) 
+			( (void (*)(void)) cpu_spin_table[core_id])();
+
 		__asm__ volatile ("wfe");
 	}
 }

--- a/smp.c
+++ b/smp.c
@@ -2,24 +2,29 @@
 #include "hobos/kstdio.h"
 
 extern int curr_core_id(void);
+extern int setup_stack(void);
 
 uint64_t *cpu_spin_table = (uint64_t *) SPIN_TABLE_BASE;
 
 //TODO: We need a mutex here to preserve a read/write order
 //for the spin table
 
+int init_smp(void)
+{	
+	int i=0;
+
+	for ( i=0; i<MAX_CORES; i++)
+		run_process((uint64_t) setup_stack, i);
+}
+
 int run_process(uint64_t fn_addr, uint8_t cpu_id)
 {
 
-	if (cpu_id > MAX_REMOTE_CORE_ID)
+	if (cpu_id >= MAX_CORES)
 		return -1;
 	
 	cpu_spin_table[cpu_id] = fn_addr;
-	
-	//data sync barrier
 	__asm__ volatile("dsb sy");
-	__asm__ volatile("sev");
-
 	return 0;
 }
 
@@ -38,10 +43,6 @@ void park_and_wait (void)
 	uint8_t core_id = curr_core_id();
 
 	while (1) {
-	
-		//data sync barrier
-		__asm__ volatile("dsb sy");
-		
 		if (cpu_spin_table[core_id]) 
 			( (void (*)(void)) cpu_spin_table[core_id])();
 

--- a/smp.c
+++ b/smp.c
@@ -52,7 +52,14 @@ int queue_on_proc(uint64_t fn_addr, uint8_t core_id)
 	 * it a special case since all ops will be sequential 
 	 * */
 	if (!core_id) {
+
+		lock_mutex(&core_exec[core_id]);
+		unlock_mutex(&core_incoming_event[core_id]);
+	
 		((void (*)(void)) fn_addr)();
+	
+		unlock_mutex(&core_exec[core_id]);
+
 		return 0;
 	}
 

--- a/smp.c
+++ b/smp.c
@@ -1,43 +1,57 @@
 #include "hobos/smp.h"
-#include "hobos/kstdio.h"
+#include "hobos/mutex.h"
 
 extern int curr_core_id(void);
 extern int setup_stack(void);
 
 uint64_t *cpu_spin_table = (uint64_t *) SPIN_TABLE_BASE;
 
-//TODO: We need a mutex here to preserve a read/write order
-//for the spin table
+
+/* In order to queue a workload we need to go through the following
+ * steps:
+ *
+ * 1) Get mutex to signal incoming event
+ * 2) Get mutex to modify the relevant core spin table entry
+ * 3) On success, modify the spintable entry (else we block and wait)
+ * 4) Release the mutex for the spintable
+ * 5) Once the function starts executing, unlock incoming event
+ * 6) If no incoming event (mutex is unlocked), get spintable mutex set spintable entry to 0x0
+ * 7) Unlock spintable mutex 
+ * 8) set spintable entry to 0x0
+ * */
+
 
 int init_smp(void)
 {	
 	int i=0;
 
-	for ( i=0; i<MAX_CORES; i++)
-		run_process((uint64_t) setup_stack, i);
+	for ( i=1; i<MAX_CORES; i++)
+		queue_on_proc((uint64_t) setup_stack, i);
 }
 
-int run_process(uint64_t fn_addr, uint8_t cpu_id)
+/* Note that this does not guarantee that the processor
+ * will start executing the given function straightaway.
+ *
+ * It only updates the spintable function address the 
+ * processor uses (see park_and_wait).
+ * */
+int queue_on_proc(uint64_t fn_addr, uint8_t cpu_id)
 {
 
 	if (cpu_id >= MAX_CORES)
 		return -1;
-	
+
+	if (!cpu_id) {
+		((void (*)(void)) fn_addr)();
+		return 0;
+	}
+
 	cpu_spin_table[cpu_id] = fn_addr;
-	__asm__ volatile("dsb sy");
+	__asm__ volatile("dsb sy; sev");
 	return 0;
 }
 
 
-//TODO:
-//if we attempt to clear or set the spin table, we might
-//lose a read or write incoming from another processor.
-//
-//This is why we need a mutex before queueing more than
-//one processors
-//
-//This current implementation works, just about, with the 
-//current implementation, but has no guarantees.
 void park_and_wait (void)
 {
 	uint8_t core_id = curr_core_id();
@@ -46,6 +60,7 @@ void park_and_wait (void)
 		if (cpu_spin_table[core_id]) 
 			( (void (*)(void)) cpu_spin_table[core_id])();
 
+		/* suspend and wait for event */
 		__asm__ volatile ("wfe");
 	}
 }

--- a/smp.c
+++ b/smp.c
@@ -32,6 +32,8 @@ int init_smp(void)
 
 	for ( i=1; i<MAX_CORES; i++)
 		queue_on_proc((uint64_t) setup_stack, i);
+
+	return 0;
 }
 
 /* Note that this does not guarantee that the processor

--- a/task.c
+++ b/task.c
@@ -1,0 +1,13 @@
+#include "hobos/lib/task.h"
+#include "hobos/lib/thread.h"
+#include "hobos/mutex.h"
+#include "hobos/kstdio.h"
+
+/*
+ * Responsible for requesting a thread id
+ * if a core is free to execute a thread.
+ * */
+void queue_task(struct task_struct *tsk)
+{
+        
+}

--- a/thread.c
+++ b/thread.c
@@ -43,15 +43,6 @@ uint8_t tid_cntr = 0;
  * */
 struct thread_struct active_threads[2*MAX_CORES] = {0x0};
 
-void init_threading(void)
-{
-    int i=0;
-
-    for (i; i<2*MAX_CORES; i++)
-	active_threads[i].tid = INACTIVE;
-}
-
-
 static void set_thread_active(struct thread_struct *t)
 {
     //get tid from pool

--- a/thread.c
+++ b/thread.c
@@ -1,0 +1,115 @@
+#include "hobos/smp.h"
+#include "hobos/mutex.h"
+#include "hobos/lib/thread.h"
+#include "hobos/kstdio.h"
+
+/* In order to queue a workload we need to go through the following
+ * steps:
+ *
+ * 1) Get mutex to signal incoming event
+ * 2) Get mutex to modify the relevant core spin table entry
+ * 3) On success, modify the spintable entry (else we block and wait)
+ * 4) Release the mutex for the spintable
+ * 5) Once the function starts executing, unlock incoming event
+ * 6) If no incoming event (mutex is unlocked), get spintable mutex set spintable entry to 0x0
+ * 7) Unlock spintable mutex 
+ * 8) set spintable entry to 0x0
+ * */
+
+
+/* for now, lets assume that all args and return
+ * is dealt with using pointers/explicit memory locations
+ * by the function itself - i.e, its the functions responsibility
+ * to be self contained.
+ */
+
+MUTEX_VECTOR(core_incoming_event, MAX_CORES) = {0};
+MUTEX(tid_cntr_mut) = 0;
+uint8_t tid_cntr = 0;
+
+/* For now, 1 core = 1 exec thread + 1 incoming thread.
+ * 
+ *  Incoming and Executing threads keep interchanging
+ *  indexes. Eg, we are executing on core 0:
+ *
+ *  	- Check for active threads for core 1
+ *  		- Both threads (at index 2,3) have .tid set as INACTIVE, so no active threads
+ *  	- Use thread at the first available index (2 in this case)
+ *  	- Convert incoming *task* to *thread* and pass it over to be queued on proc
+ *  	- Wait for execution to complete and cleanup
+ *
+ * Once threads can be paused/suspended - for instance, in
+ * case of IO, we can increase this number
+ * */
+struct thread_struct active_threads[2*MAX_CORES] = {0x0};
+
+void init_threading(void)
+{
+    int i=0;
+
+    for (i; i<2*MAX_CORES; i++)
+	active_threads[i].tid = INACTIVE;
+}
+
+
+static void set_thread_active(struct thread_struct *t)
+{
+    //get tid from pool
+    lock_mutex(&tid_cntr_mut);
+    t->tid = tid_cntr++;
+    unlock_mutex(&tid_cntr_mut);
+}
+
+
+static void set_thread_inactive(struct thread_struct *t)
+{
+    //send tid back to pool
+    lock_mutex(&tid_cntr_mut);
+    tid_cntr--;
+    t->tid = INACTIVE;
+    unlock_mutex(&tid_cntr_mut);
+}
+
+//TODO: return some error code
+void queue_thread(struct task_struct *tsk)
+{
+    uint8_t pref_core = tsk->core_id;
+    struct thread_struct *t;
+
+    lock_mutex(&core_incoming_event[pref_core]);
+    if (pref_core >= MAX_CORES)
+	return;
+
+    t = &active_threads[pref_core*2];
+
+    if (t->tid != INACTIVE) 
+	t = &active_threads[pref_core*2+1];
+    
+    
+    t->core_id = tsk->core_id; 
+    t->fn_addr =  tsk->fn_addr;
+    set_thread_active(t);
+    
+    tsk->tid = t->tid;
+
+    //PRINT_THREAD(t);
+
+   // if (pref_core == ANY_CORE) {
+   //     while(1) {
+   //         //TODO:
+   //         //for(i=0; i<MAX_CORES; i++)
+   //        //try_and_get_mutex(); 	    
+   //     }
+   // } else {
+    //	queue_on_proc(t->fn_addr, t->core_id);
+    //}
+
+    queue_on_proc(t->fn_addr, t->core_id);
+    set_thread_inactive(t);
+
+}
+
+uint8_t incoming_thread_exists(uint8_t core_id)
+{
+    return get_mutex_state(&core_incoming_event[core_id]);
+}


### PR DESCRIPTION
Adding rudimentary support for multiprocessing.

More specifically adding support for:
- Mutexes
- Threading

Will need to add IRQ support to allow for preemption - i.e, GIC support is needed to continue. Once done, a simple dedicated scheduler with multiple queues can be established.


To test:

```
make
qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial null -serial stdio -s
```
Expected Output:
```
Hello again 1  *
Hello again 1 1 *
Hello again 2 *
Hello again 1 2 *
Hello again 2 1*
Hello again 1 3 *
Hello again 2 2*
Hello again 2 3*
Hello again 2 4*
Hello again 3 *
sp: 0x800B4 pc: 0x800BC_
Hello again 3 1*
```

NOTE: Certain trailing characters are being printed during formatted prints when formatting with numbers. This will be fixed in further commits but ignoring this for now